### PR TITLE
Request/Response.Body не восстанавливались после логгирования

### DIFF
--- a/RequestLogger.AzureTable/RequestLogger.AzureTable.Demo/Startup.cs
+++ b/RequestLogger.AzureTable/RequestLogger.AzureTable.Demo/Startup.cs
@@ -38,6 +38,8 @@ namespace RequestLogger.AzureTable.Demo
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
+            app.UseDeveloperExceptionPage();
+
             app.UseStaticFiles();
             //@"UseDevelopmentStorage=true;", "AzureLoggerDemo", new string[] { "demo" }, new TimeSpan(0, 0, 30)
             app.UseRequestLogger(new RequestLoggerOptions()
@@ -48,6 +50,20 @@ namespace RequestLogger.AzureTable.Demo
                 Interval = new TimeSpan(0,0,30)           
             });
             // Add external authentication middleware below. To configure them please see http://go.microsoft.com/fwlink/?LinkID=532715
+
+            app.Use(async (context, next) =>
+            {
+                if (context.Request.Path == "/fail/demo")
+                {
+                    throw new Exception();
+                }
+                if (context.Request.Path == "/fail/foobar")
+                {
+                    throw new Exception();
+                }
+                await next.Invoke();
+            });
+
 
             app.UseMvc(routes =>
             {

--- a/RequestLogger.AzureTable/RequestLogger.AzureTable.Demo/project.json
+++ b/RequestLogger.AzureTable/RequestLogger.AzureTable.Demo/project.json
@@ -14,6 +14,7 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging": "1.0.0-rc2-final",

--- a/RequestLogger.AzureTable/RequestLogger.AzureTable.Demo/project.lock.json
+++ b/RequestLogger.AzureTable/RequestLogger.AzureTable.Demo/project.lock.json
@@ -141,6 +141,27 @@
           "lib/netstandard1.3/Microsoft.AspNetCore.DataProtection.Abstractions.dll": {}
         }
       },
+      "Microsoft.AspNetCore.Diagnostics/1.0.0-rc2-final": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.AspNetCore.Diagnostics.Abstractions": "1.0.0-rc2-final",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0-rc2-final",
+          "Microsoft.AspNetCore.Http.Extensions": "1.0.0-rc2-final",
+          "Microsoft.AspNetCore.WebUtilities": "1.0.0-rc2-final",
+          "Microsoft.Extensions.FileProviders.Physical": "1.0.0-rc2-final",
+          "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-final",
+          "Microsoft.Extensions.Options": "1.0.0-rc2-final",
+          "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-final",
+          "System.Diagnostics.DiagnosticSource": "4.0.0-rc2-24027",
+          "System.Reflection.Extensions": "4.0.1-rc2-24027"
+        },
+        "compile": {
+          "lib/netstandard1.3/Microsoft.AspNetCore.Diagnostics.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/Microsoft.AspNetCore.Diagnostics.dll": {}
+        }
+      },
       "Microsoft.AspNetCore.Diagnostics.Abstractions/1.0.0-rc2-final": {
         "type": "package",
         "dependencies": {
@@ -4270,6 +4291,18 @@
         "lib/net451/Microsoft.AspNetCore.DataProtection.Abstractions.xml",
         "lib/netstandard1.3/Microsoft.AspNetCore.DataProtection.Abstractions.dll",
         "lib/netstandard1.3/Microsoft.AspNetCore.DataProtection.Abstractions.xml"
+      ]
+    },
+    "Microsoft.AspNetCore.Diagnostics/1.0.0-rc2-final": {
+      "sha512": "tkTheYd1QfRQLxMv52leqiUDl5zPrIn/oRjzajITxOcZuKQKRSb8uLLF3cK9JiDoMVh/G6yCeglycDIhk8c0Kw==",
+      "type": "package",
+      "files": [
+        "Microsoft.AspNetCore.Diagnostics.1.0.0-rc2-final.nupkg.sha512",
+        "Microsoft.AspNetCore.Diagnostics.nuspec",
+        "lib/net451/Microsoft.AspNetCore.Diagnostics.dll",
+        "lib/net451/Microsoft.AspNetCore.Diagnostics.xml",
+        "lib/netstandard1.3/Microsoft.AspNetCore.Diagnostics.dll",
+        "lib/netstandard1.3/Microsoft.AspNetCore.Diagnostics.xml"
       ]
     },
     "Microsoft.AspNetCore.Diagnostics.Abstractions/1.0.0-rc2-final": {
@@ -10625,6 +10658,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
+      "Microsoft.AspNetCore.Diagnostics >= 1.0.0-rc2-final",
       "Microsoft.AspNetCore.Mvc >= 1.0.0-rc2-final",
       "Microsoft.AspNetCore.Razor.Tools >= 1.0.0-preview1-final",
       "Microsoft.AspNetCore.Server.IISIntegration >= 1.0.0-rc2-final",

--- a/RequestLogger.AzureTable/src/RequestLogger.AzureTable/RequestLoggerMiddleware.cs
+++ b/RequestLogger.AzureTable/src/RequestLogger.AzureTable/RequestLoggerMiddleware.cs
@@ -51,6 +51,7 @@
 
                 _logger.LogInformation("Log to RequestLogger...");
 
+                var requestStream = context.Request.Body;
                 var requestBuffer = new MemoryStream();
                 await context.Request.Body.CopyToAsync(requestBuffer);
 
@@ -98,6 +99,9 @@
                 }
                 finally
                 {
+                    context.Request.Body = requestStream;
+                    context.Response.Body = responseStream;
+
                     AzureTableService.Instance.Log(requestBody, responseBody, path, query, requestLenght, responseLenght, code, sw.ElapsedMilliseconds, exception);
                 }
 


### PR DESCRIPTION
Ссылки на исходные стримы (Request.Body, Response.Body) не восстанавливались после логгирования, что приводило к проблемам если другие middleware как-то обрабатывали ответ, читая его из Response.Body.

В частности DeveloperExceptionPage переставал показываться. Для демонстрации надо закомментировать изменения в `RequestLoggerMiddleware` и сравнить ответ демоприложения по ссылкам `/fail/demo` и `/fail/foobar` - первый адрес попадает под логгирование и по нему не показывается страница исключения.
